### PR TITLE
Update Dockerfile to match alpine version between build & run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p /opt/rel && \
     ./rebar3 as prod tar && \
     tar -zxvf $REBAR_BASE_DIR/prod/rel/*/*.tar.gz -C /opt/rel
 
-FROM alpine:3.16 as runner
+FROM alpine:3.17 as runner
 
 RUN apk add --update openssl libsodium ncurses libstdc++
 


### PR DESCRIPTION
Without this, you get
```
/opt/blockchain_http
Error relocating /opt/blockchain_http/erts-12.3.2.16/bin/beam.smp: extendhfdf2: symbol not found
Error relocating /opt/blockchain_http/erts-12.3.2.16/bin/beam.smp: truncdfhf2: symbol not found
Error relocating /opt/blockchain_http/erts-12.3.2.16/bin/beam.smp: __truncxfhf2: symbol not found
Exec: /opt/blockchain_http/erts-12.3.2.16/bin/erlexec -noinput +Bd -boot /opt/blockchain_http/releases/1.2.130/start -mode embedded -boot_var SYSTEM_LIB_DIR /opt/blockchain_http/lib -config /opt/blockchain_http/releases/1.2.130/sys.config -args_file /opt/blockchain_http/releases/1.2.130/vm.args -- foreground
```
at runtime because erlang-24 use alpine 3.17 and runtime was using alpine 3.16.

I assume the erlang-24 sub version has a alpine version upgrade.